### PR TITLE
Add Japanese usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,13 @@ python -m img2prompt.cli path/to/image.jpg
 ```
 
 The command writes `path/to/image.jpg.prompt.json` containing the prompt data.
+
+## 使い方
+
+以下のコマンドで、入力画像からプロンプトのJSONファイルを生成します。
+
+```bash
+python -m img2prompt.cli path/to/image.jpg
+```
+
+実行すると `path/to/image.jpg.prompt.json` が作成され、画像から抽出したプロンプト情報が保存されます。


### PR DESCRIPTION
## Summary
- document CLI usage in Japanese

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad9353e0ac832886538e250a8cd10a