### PR TITLE
Replace BLIP & DeepDanbooru placeholders with Florence and WD14

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Prototype CLI utility to generate prompt JSON from an input image.
 
+The current prototype uses lightweight stand-ins for several common
+extraction models:
+
+* **Florence-2** for caption generation
+* **WD14** for anime-focused tagging
+* **CLIP Interrogator** for style and lighting hints
+
 ## Setup
 
 ```bash

--- a/img2prompt/cli.py
+++ b/img2prompt/cli.py
@@ -1,17 +1,17 @@
 import argparse
 from pathlib import Path
 
-from .extract import blip, clip_interrogator, deepdanbooru
+from .extract import florence, clip_interrogator, wd14
 from .assemble import normalize, bucketize, palette
 from .export import writer
 
 
 def run(image_path: str) -> Path:
     image_path = Path(image_path)
-    caption = blip.generate_caption(image_path)
+    caption = florence.generate_caption(image_path)
     tags = []
     tags.extend(clip_interrogator.extract_tags(image_path))
-    tags.extend(deepdanbooru.extract_tags(image_path))
+    tags.extend(wd14.extract_tags(image_path))
     tags = normalize.normalize_tags(tags)
     buckets = bucketize.bucketize(tags)
     ordered = []

--- a/img2prompt/extract/blip.py
+++ b/img2prompt/extract/blip.py
@@ -1,6 +1,0 @@
-from pathlib import Path
-
-
-def generate_caption(path: Path) -> str:
-    """Return a placeholder caption for the image."""
-    return "a placeholder caption"

--- a/img2prompt/extract/deepdanbooru.py
+++ b/img2prompt/extract/deepdanbooru.py
@@ -1,7 +1,0 @@
-from pathlib import Path
-from typing import List
-
-
-def extract_tags(path: Path) -> List[str]:
-    """Return placeholder anime tags."""
-    return ["girl", "smile", "blue eyes", "brown hair"]

--- a/img2prompt/extract/florence.py
+++ b/img2prompt/extract/florence.py
@@ -1,0 +1,16 @@
+"""Placeholder caption extraction using Florence-2."""
+
+from pathlib import Path
+
+
+def generate_caption(path: Path) -> str:
+    """Return a stand-in caption for the image.
+
+    The real project would invoke a Florence-2 model to produce a rich
+    description.  For the purposes of the kata we simply return a fixed
+    string so the rest of the pipeline can be exercised without heavy
+    dependencies.
+    """
+
+    return "a detailed caption from Florence-2"
+

--- a/img2prompt/extract/wd14.py
+++ b/img2prompt/extract/wd14.py
@@ -1,0 +1,16 @@
+"""Placeholder WD14 tag extraction."""
+
+from pathlib import Path
+from typing import List
+
+
+def extract_tags(path: Path) -> List[str]:
+    """Return example tags that WD14 might produce.
+
+    A real implementation would load the ConvNeXtV2 based tagger and
+    perform inference on ``path``.  Here we simply return a short list of
+    deterministic tags to keep the example lightweight.
+    """
+
+    return ["1girl", "smile", "blue eyes", "brown hair"]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ transformers
 timm
 einops
 clip-interrogator==0.6.0
-deepdanbooru
 onnxruntime
 scikit-learn


### PR DESCRIPTION
## Summary
- swap BLIP caption stub for Florence-2 stand‑in
- replace DeepDanbooru tags with WD14 stub and update CLI
- remove deepdanbooru dependency and document placeholder extractors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68add77618308328b4c4d96e723dbfc0