### PR TITLE
docs: update README for real inference and Windows setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Prototype CLI utility to generate prompt JSON from an input image.
 
-The current prototype uses lightweight stand-ins for several common
+The current prototype runs real inference using the following
 extraction models:
 
 * **Florence-2** for caption generation
@@ -13,6 +13,14 @@ extraction models:
 
 ```bash
 python -m venv .venv && . .venv/bin/activate
+pip install -r requirements.txt
+```
+
+On Windows use:
+
+```powershell
+python -m venv .venv
+.venv\Scripts\activate
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
## Summary
- clarify that the tool now runs real inference using Florence-2, WD14, and CLIP Interrogator
- add Windows virtual environment setup instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade79cfaa48328a284adde6403c267