### PR TITLE
Add minimal tests and validation utilities

### DIFF
--- a/img2prompt/assemble/style_picker.py
+++ b/img2prompt/assemble/style_picker.py
@@ -1,0 +1,12 @@
+from typing import Iterable
+
+ANIME_KEYWORDS = {"anime", "manga", "cartoon"}
+
+
+def pick_style(tags: Iterable[str]) -> str:
+    """Return ``"anime"`` if tags hint at animation, else ``"photo"``."""
+    for tag in tags:
+        lower = tag.lower()
+        if any(keyword in lower for keyword in ANIME_KEYWORDS):
+            return "anime"
+    return "photo"

--- a/img2prompt/export/writer.py
+++ b/img2prompt/export/writer.py
@@ -31,26 +31,45 @@ REQUIRED_META = {"palette_hex", "tags_debug"}
 
 
 def validate_prompt(data: dict) -> None:
-    """Very small validator ensuring required keys exist."""
+    """Very small validator ensuring required keys, types and ranges."""
 
     missing = REQUIRED_TOP_LEVEL - data.keys()
     if missing:
         raise ValueError(f"missing keys: {sorted(missing)}")
 
+    for key in ["caption", "prompt", "negative_prompt", "style", "model_suggestion"]:
+        if not isinstance(data.get(key), str):
+            raise ValueError(f"{key} must be a string")
+
     params = data.get("params", {})
     missing = REQUIRED_PARAMS - params.keys()
     if missing:
         raise ValueError(f"params missing keys: {sorted(missing)}")
+    for key in ["width", "height", "steps", "cfg_scale"]:
+        value = params.get(key)
+        if not isinstance(value, int) or value < 0:
+            raise ValueError(f"params.{key} must be a non-negative int")
+    if not isinstance(params.get("sampler"), str):
+        raise ValueError("params.sampler must be a string")
+    if not isinstance(params.get("seed"), (str, int)):
+        raise ValueError("params.seed must be a string or int")
 
     controls = data.get("control_suggestions", {})
     missing = REQUIRED_CONTROLS - controls.keys()
     if missing:
         raise ValueError(f"control_suggestions missing keys: {sorted(missing)}")
+    for key in REQUIRED_CONTROLS:
+        if not isinstance(controls.get(key), bool):
+            raise ValueError(f"control_suggestions.{key} must be a boolean")
 
     meta = data.get("meta", {})
     missing = REQUIRED_META - meta.keys()
     if missing:
         raise ValueError(f"meta missing keys: {sorted(missing)}")
+    if not isinstance(meta.get("palette_hex"), list):
+        raise ValueError("meta.palette_hex must be a list")
+    if not isinstance(meta.get("tags_debug"), dict):
+        raise ValueError("meta.tags_debug must be a dict")
 
 
 def write_prompt(path: Path, data: dict) -> None:

--- a/tests/test_bucketize.py
+++ b/tests/test_bucketize.py
@@ -7,9 +7,10 @@ sys.path.append(str(ROOT))
 from img2prompt.assemble import bucketize
 
 
-def test_bucketize_generates_minimum_tags():
+def test_bucketize_generates_unique_tags():
     tags = ["person", "hair", "outdoor", "close up", "soft lighting"]
     buckets = bucketize.bucketize(tags)
-    assert all(len(v) >= 5 for v in buckets.values())
-    total = sum(len(v) for v in buckets.values())
+    all_tags = [t for v in buckets.values() for t in v]
+    assert len(all_tags) == len(set(all_tags))
+    total = len(all_tags)
     assert 50 <= total <= 70

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,6 +2,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
@@ -10,7 +12,32 @@ from img2prompt.export import writer
 EXAMPLE_PATH = ROOT / "examples" / "sample.prompt.json"
 
 
-def test_example_conforms_to_schema():
+def load_example() -> dict:
     with open(EXAMPLE_PATH, "r", encoding="utf-8") as f:
-        data = json.load(f)
+        return json.load(f)
+
+
+def test_example_conforms_to_schema():
+    data = load_example()
     writer.validate_prompt(data)
+
+
+def test_missing_required_key_raises():
+    data = load_example()
+    del data["prompt"]
+    with pytest.raises(ValueError):
+        writer.validate_prompt(data)
+
+
+def test_invalid_type_raises():
+    data = load_example()
+    data["caption"] = 123
+    with pytest.raises(ValueError):
+        writer.validate_prompt(data)
+
+
+def test_invalid_range_raises():
+    data = load_example()
+    data["params"]["width"] = -1
+    with pytest.raises(ValueError):
+        writer.validate_prompt(data)

--- a/tests/test_style_picker.py
+++ b/tests/test_style_picker.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from img2prompt.assemble import style_picker
+
+
+def test_pick_style_anime():
+    tags = ["anime", "blue hair"]
+    assert style_picker.pick_style(tags) == "anime"
+
+
+def test_pick_style_photo():
+    tags = ["portrait", "outdoor"]
+    assert style_picker.pick_style(tags) == "photo"


### PR DESCRIPTION
## Summary
- Ensure bucketize yields unique tags and stays within 50-70 items
- Add manual schema validation for types and ranges
- Introduce simple style picker with anime/photo unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade7bc23d483289e10b87e8099ab23