### PR TITLE
Add logging warnings and usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,24 @@ python -m img2prompt.cli path/to/image.jpg
 ```
 
 The command writes `path/to/image.jpg.prompt.json` containing the prompt data.
+For example:
+
+```bash
+$ python -m img2prompt.cli examples/sample.jpg
+examples/sample.jpg.prompt.json
+```
+
+The generated file resembles:
+
+```json
+{
+  "caption": "a detailed caption from Florence-2",
+  "prompt": "person, hair, outdoor, close up, soft lighting, ...",
+  "negative_prompt": "low quality, worst quality, blurry, jpeg artifacts, watermark, text, extra fingers, deformed hands, bad anatomy",
+  "style": "anime",
+  "model_suggestion": ""
+}
+```
 
 ## 使い方
 

--- a/img2prompt/cli.py
+++ b/img2prompt/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 from pathlib import Path
 
 from .extract import florence, clip_interrogator, wd14
@@ -6,18 +7,56 @@ from .assemble import normalize, bucketize, palette
 from .export import writer
 
 
+logger = logging.getLogger(__name__)
+
+
 def run(image_path: str) -> Path:
     image_path = Path(image_path)
-    caption = florence.generate_caption(image_path)
-    tags = []
-    tags.extend(clip_interrogator.extract_tags(image_path))
-    tags.extend(wd14.extract_tags(image_path))
-    tags = normalize.normalize_tags(tags)
-    buckets = bucketize.bucketize(tags)
-    ordered = []
+    try:
+        caption = florence.generate_caption(image_path)
+        if not caption:
+            logger.warning("Caption generation returned empty for %s", image_path)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("Caption generation failed for %s: %s", image_path, exc)
+        caption = ""
+
+    tags: list[str] = []
+    for extractor in (clip_interrogator.extract_tags, wd14.extract_tags):
+        try:
+            tags.extend(extractor(image_path))
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("%s failed for %s: %s", extractor.__name__, image_path, exc)
+    if not tags:
+        logger.warning("No tags extracted for %s", image_path)
+
+    try:
+        tags = normalize.normalize_tags(tags)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("Tag normalization failed for %s: %s", image_path, exc)
+        tags = []
+    try:
+        buckets = bucketize.bucketize(tags)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("Bucketizing tags failed for %s: %s", image_path, exc)
+        buckets = {}
+
+    ordered: list[str] = []
     for key in ["subject", "appearance", "scene", "composition", "style_lighting"]:
         ordered.extend(buckets.get(key, []))
+    if not ordered:
+        logger.warning("No ordered tags produced for %s", image_path)
     prompt = ", ".join(ordered)
+    if not prompt:
+        logger.warning("Prompt is empty for %s", image_path)
+
+    try:
+        palette_hex = palette.extract_palette(image_path)
+        if not palette_hex:
+            logger.warning("Palette extraction returned no colours for %s", image_path)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("Palette extraction failed for %s: %s", image_path, exc)
+        palette_hex = []
+
     data = {
         "caption": caption,
         "prompt": prompt,
@@ -37,12 +76,16 @@ def run(image_path: str) -> Path:
             "openpose": False,
         },
         "meta": {
-            "palette_hex": palette.extract_palette(image_path),
+            "palette_hex": palette_hex,
             "tags_debug": {"stub": {t: 1.0 for t in ordered}},
         },
     }
     out_path = image_path.with_name(image_path.name + ".prompt.json")
-    writer.write_prompt(out_path, data)
+    try:
+        writer.write_prompt(out_path, data)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.warning("Failed to write prompt for %s: %s", image_path, exc)
+        raise
     return out_path
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ einops
 clip-interrogator==0.6.0
 onnxruntime
 scikit-learn
+pytest


### PR DESCRIPTION
## Summary
- log warnings for caption/tag/palette extraction failures
- document sample command and JSON output in README
- include pytest in requirements for running tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade7c5ea8883289e498c87ed21f5f1