### PR TITLE
Improve logging and document sample usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ python -m img2prompt.cli path\to\image.jpg
 
 The command writes `path/to/image.jpg.prompt.json` containing the prompt data.
 
+Example:
+
+```bash
+$ python -m img2prompt.cli examples/sample.jpg
+```
+
+The resulting `examples/sample.jpg.prompt.json` looks like:
+
+```json
+{
+  "caption": "a girl smiling",
+  "prompt": "1girl, smile, outdoor",
+  "negative_prompt": "low quality, worst quality",
+  "style": "anime",
+  "model_suggestion": "unspecified"
+}
+```
+
 ## 使い方
 
 以下のコマンドで、入力画像からプロンプトのJSONファイルを生成します。

--- a/img2prompt/assemble/palette.py
+++ b/img2prompt/assemble/palette.py
@@ -32,6 +32,6 @@ def extract_palette(path: Path, colors: int = 5) -> List[str]:
         cleaned = [h if h.lower() != "#000000" else "#010101" for h in hexes]
         return cleaned[:colors]
     except Exception as exc:  # pragma: no cover - fallback path
-        logger.exception("Palette extraction failed: %s", exc)
+        logger.warning("Palette extraction failed: %s", exc)
         fallback = ["#010101", "#020202", "#030303", "#040404", "#050505"]
         return fallback[:colors]

--- a/img2prompt/export/writer.py
+++ b/img2prompt/export/writer.py
@@ -115,7 +115,7 @@ def write_prompt(path: Path, data: dict) -> None:
         validate_prompt(data)
         to_write = data
     except Exception as exc:  # pragma: no cover - fallback path
-        logger.exception("Prompt validation failed: %s", exc)
+        logger.warning("Prompt validation failed: %s", exc)
         to_write = DEFAULT_DATA
 
     path = Path(path)

--- a/img2prompt/extract/blip.py
+++ b/img2prompt/extract/blip.py
@@ -27,7 +27,7 @@ def _load() -> None:
         )
         _model.eval()
     except Exception as exc:  # pragma: no cover - fallback path
-        logger.exception("Failed to load BLIP model: %s", exc)
+        logger.warning("Failed to load BLIP model: %s", exc)
         _processor = None
         _model = None
 
@@ -53,5 +53,5 @@ def generate_caption(path: Path) -> str:
         caption = _processor.decode(out[0], skip_special_tokens=True).strip()
         return caption or "an image"
     except Exception as exc:  # pragma: no cover - fallback path
-        logger.exception("Caption generation failed: %s", exc)
+        logger.warning("Caption generation failed: %s", exc)
         return "an image"

--- a/img2prompt/extract/clip_interrogator.py
+++ b/img2prompt/extract/clip_interrogator.py
@@ -36,5 +36,5 @@ def extract_tags(path: Path) -> Dict[str, float]:
                 result[cand] = 0.55
         return result
     except Exception as exc:  # pragma: no cover - fallback path
-        logger.exception("CLIP Interrogator failed: %s", exc)
+        logger.warning("CLIP Interrogator failed: %s", exc)
         return {}

--- a/img2prompt/extract/deepdanbooru.py
+++ b/img2prompt/extract/deepdanbooru.py
@@ -23,7 +23,7 @@ def _load() -> None:
         _tags = dd.project.load_tags_from_project(project_path)
         _model.eval()
     except Exception as exc:  # pragma: no cover - fallback path
-        logger.exception("Failed to load DeepDanbooru model: %s", exc)
+        logger.warning("Failed to load DeepDanbooru model: %s", exc)
         _model = None
         _tags = None
 
@@ -57,5 +57,5 @@ def extract_tags(path: Path, threshold: float = 0.35) -> Dict[str, float]:
                 result[tag] = float(score)
         return result
     except Exception as exc:  # pragma: no cover - fallback path
-        logger.exception("DeepDanbooru inference failed: %s", exc)
+        logger.warning("DeepDanbooru inference failed: %s", exc)
         return {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pillow
 transformers
 timm
 einops
+numpy
 
 clip-interrogator==0.6.0
 open-clip-torch


### PR DESCRIPTION
## Summary
- log warnings when feature extraction or validation fall back to defaults
- document sample command and resulting JSON in README usage section
- add numpy dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adf2a9a814832899df75130ec47303