### PR TITLE
Improve tag extraction robustness and fallback logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 * **Florence-2** : キャプション生成
 * **WD14** : アニメ向けタグ抽出
 * **CLIP Interrogator** : スタイルとライティングのヒント
+* **DeepDanbooru** (オプション) : 追加タグ抽出。Windowsでは `tensorflow-io` の問題により非推奨。必要な場合は `tensorflow-cpu==2.12.*` と `tensorflow-io-gcs-filesystem==0.31.0` を手動でインストールしてください。
 
 ## セットアップ
 

--- a/img2prompt/assemble/palette.py
+++ b/img2prompt/assemble/palette.py
@@ -22,8 +22,11 @@ def extract_palette(path: Path, colors: int = 5) -> List[str]:
         from sklearn.cluster import KMeans
 
         image = Image.open(path).convert("RGB")
-        arr = np.array(image).reshape(-1, 3)
-        kmeans = KMeans(n_clusters=colors, n_init=10)
+        arr = np.array(image)
+        if arr.ndim != 3 or arr.shape[2] != 3 or arr.size < colors * 3:
+            raise ValueError("invalid image array")
+        arr = arr.reshape(-1, 3)
+        kmeans = KMeans(n_clusters=colors, n_init=4)
         kmeans.fit(arr)
         centres = kmeans.cluster_centers_.astype(int)
         hexes = ["#{:02x}{:02x}{:02x}".format(*c) for c in centres]

--- a/img2prompt/cli.py
+++ b/img2prompt/cli.py
@@ -1,23 +1,55 @@
 import argparse
 from pathlib import Path
 import re
+import logging
 
 from .extract import blip, clip_interrogator, deepdanbooru, wd14_onnx
 from .assemble import normalize, bucketize, palette, style
 from .export import writer
+
+logger = logging.getLogger(__name__)
 
 
 def run(image_path: str) -> Path:
     image_path = Path(image_path)
     caption = blip.generate_caption(image_path)
 
-    wd_raw = wd14_onnx.extract_tags(image_path)
-    dd_raw = deepdanbooru.extract_tags(image_path)
-    ci_raw, ci_text = clip_interrogator.extract_tags(image_path)
+    # --- tag extraction with error capture
+    tags_debug = {}
 
-    wd_tags = normalize.remove_placeholders(wd_raw)
-    dd_tags = normalize.remove_placeholders(dd_raw)
-    ci_tags = normalize.remove_placeholders(ci_raw)
+    try:
+        wd_raw = wd14_onnx.extract_tags(image_path)
+        wd_tags = normalize.remove_placeholders(wd_raw)
+        tags_debug["wd14_onnx"] = {"count": len(wd_tags), "ok": True}
+    except Exception as exc:  # pragma: no cover - should be rare
+        logger.warning("WD14 extractor failed: %s", exc, exc_info=True)
+        wd_tags = {}
+        tags_debug["wd14_onnx"] = {"count": 0, "ok": False, "error": str(exc)}
+
+    try:
+        dd_raw = deepdanbooru.extract_tags(image_path)
+        dd_tags = normalize.remove_placeholders(dd_raw)
+        tags_debug["deepdanbooru"] = {"count": len(dd_tags), "ok": True}
+    except Exception as exc:  # pragma: no cover - should be rare
+        logger.warning("DeepDanbooru extractor failed: %s", exc, exc_info=True)
+        dd_tags = {}
+        tags_debug["deepdanbooru"] = {"count": 0, "ok": False, "error": str(exc)}
+
+    try:
+        ci_raw, ci_text, ci_fb = clip_interrogator.extract_tags(image_path)
+        ci_tags = normalize.remove_placeholders(ci_raw)
+        tags_debug["clip_interrogator"] = {
+            "count": len(ci_tags),
+            "fallback_chunks": ci_fb,
+        }
+    except Exception as exc:  # pragma: no cover - should be rare
+        logger.warning("CLIP Interrogator extractor failed: %s", exc, exc_info=True)
+        ci_tags, ci_text = {}, ""
+        tags_debug["clip_interrogator"] = {
+            "count": 0,
+            "fallback_chunks": 0,
+            "error": str(exc),
+        }
 
     merged = normalize.merge_tags(wd_tags, dd_tags, ci_tags)
     buckets = bucketize.bucketize(merged)
@@ -34,20 +66,51 @@ def run(image_path: str) -> Path:
         ordered.extend(buckets.get(key, []))
 
     def ensure_minimum_tags(existing, caption_text, ci_text_raw):
-        tags = list(dict.fromkeys(existing))
+        def clean_tokens(seq):
+            cleaned = []
+            for t in seq:
+                t = t.strip().lower()
+                if not re.fullmatch(r"[a-z ]{2,48}", t):
+                    continue
+                cleaned.append(t)
+            # remove simple proper names
+            COMMON_NAMES = {
+                "john",
+                "mary",
+                "michael",
+                "david",
+                "james",
+                "jennifer",
+                "lisa",
+                "robert",
+                "mark",
+                "paul",
+            }
+
+            def looks_like_name(phrase: str) -> bool:
+                parts = phrase.split()
+                return len(parts) == 2 and all(p in COMMON_NAMES for p in parts)
+
+            return [t for t in cleaned if not looks_like_name(t)]
+
+        tags = clean_tokens(dict.fromkeys(existing))
         if len(tags) >= 50:
             return tags[:70]
+
         caption_text = caption_text.lower()
-        for phrase in re.findall(r"[a-z]+(?: [a-z]+){0,3}", caption_text):
+        caption_phrases = re.findall(r"[a-z]+(?: [a-z]+){0,3}", caption_text)
+        for phrase in clean_tokens(caption_phrases):
             if phrase not in tags:
                 tags.append(phrase)
             if len(tags) >= 50:
                 break
         if len(tags) < 50:
             for chunk in re.split(r"[,\n]", ci_text_raw.lower()):
-                w = chunk.strip()
-                if w and w not in tags:
-                    tags.append(w)
+                for phrase in clean_tokens([chunk]):
+                    if phrase not in tags:
+                        tags.append(phrase)
+                    if len(tags) >= 50:
+                        break
                 if len(tags) >= 50:
                     break
         if len(tags) < 50:
@@ -59,6 +122,8 @@ def run(image_path: str) -> Path:
                 "warm tones",
                 "sharp focus",
                 "depth of field",
+                "wooden interior",
+                "window light",
             ]
             for w in fallback:
                 if w not in tags:
@@ -87,11 +152,7 @@ def run(image_path: str) -> Path:
         },
         "meta": {
             "palette_hex": palette.extract_palette(image_path),
-            "tags_debug": {
-                "wd14_onnx": wd_tags,
-                "deepdanbooru": dd_tags,
-                "clip_interrogator": ci_tags,
-            },
+            "tags_debug": tags_debug,
         },
     }
     out_path = image_path.with_name(image_path.name + ".prompt.json")

--- a/img2prompt/extract/clip_interrogator.py
+++ b/img2prompt/extract/clip_interrogator.py
@@ -20,8 +20,8 @@ CANDIDATES = [
 ]
 
 
-def extract_tags(path: Path) -> Tuple[Dict[str, float], str]:
-    """Run the interrogator and return detected lighting/style tags and raw text."""
+def extract_tags(path: Path) -> Tuple[Dict[str, float], str, int]:
+    """Run the interrogator and return tags, raw text, and fallback count."""
     try:
         from clip_interrogator import Config, Interrogator
         from PIL import Image
@@ -64,10 +64,10 @@ def extract_tags(path: Path) -> Tuple[Dict[str, float], str]:
         for w in picks[:15]:
             result.setdefault(w, 0.50)
 
-        return result, text
+        return result, text, len(picks[:15])
     except Exception as exc:  # pragma: no cover - fallback path
         logger.warning("CLIP Interrogator failed: %s", exc, exc_info=True)
-        return {}, ""
+        return {}, "", 0
 
 
 def extract_text(path: Path) -> str:

--- a/img2prompt/extract/wd14_onnx.py
+++ b/img2prompt/extract/wd14_onnx.py
@@ -1,24 +1,48 @@
-"""WD14 (ConvNeXtV2) ONNX tagger."""
+"""WD14 (ConvNeXtV2) ONNX tagger with auto-download and robust I/O."""
 from pathlib import Path
 from typing import Dict
 import logging
-import onnxruntime as ort
+
 import numpy as np
+import onnxruntime as ort
 from PIL import Image
+from huggingface_hub import hf_hub_download
 
 logger = logging.getLogger(__name__)
+
+MODEL_REPO = "SmilingWolf/wd-v1-4-convnextv2-tagger-v2"
+MODEL_FILE = "wd14-convnextv2.onnx"
+TAGS_FILE = "tags.csv"
 
 _session = None
 _tags = None
 
 
-def _load():
+def _ensure_files(model_dir: Path) -> Path:
+    """Ensure model and tag files exist, downloading if necessary."""
+    model_dir.mkdir(parents=True, exist_ok=True)
+    model_path = model_dir / MODEL_FILE
+    tags_path = model_dir / TAGS_FILE
+    try:
+        if not model_path.exists():
+            hf_hub_download(MODEL_REPO, MODEL_FILE, local_dir=model_dir, local_dir_use_symlinks=False)
+        if not tags_path.exists():
+            hf_hub_download(MODEL_REPO, TAGS_FILE, local_dir=model_dir, local_dir_use_symlinks=False)
+    except Exception as exc:  # pragma: no cover - network failures
+        logger.warning("WD14 model download failed: %s", exc, exc_info=True)
+    return model_path, tags_path
+
+
+def _load() -> None:
+    """Lazily load ONNX session and tags."""
     global _session, _tags
     if _session is not None and _tags is not None:
         return
     try:
-        model_path = Path("models/wd14-convnextv2.onnx")
-        tags_path = Path("models/tags.csv")
+        base = Path(__file__).resolve().parent / "models"
+        model_path, tags_path = _ensure_files(base)
+        if not model_path.exists() or not tags_path.exists():
+            raise FileNotFoundError("WD14 model files missing")
         _session = ort.InferenceSession(str(model_path), providers=["CPUExecutionProvider"])
         _tags = [l.strip() for l in tags_path.read_text(encoding="utf-8").splitlines()]
     except Exception as exc:
@@ -27,11 +51,18 @@ def _load():
 
 
 def extract_tags(path: Path, threshold: float = 0.35) -> Dict[str, float]:
+    """Return tags for ``path`` using the WD14 ONNX model."""
     try:
         _load()
         if _session is None or _tags is None:
             raise RuntimeError("WD14 unavailable")
-        img = Image.open(path).convert("RGB").resize((448, 448), Image.BICUBIC)
+
+        img = Image.open(path)
+        if img.mode != "RGB":
+            img = img.convert("RGB")
+        if min(img.size) < 32:
+            raise ValueError("image too small")
+        img = img.resize((448, 448), Image.BICUBIC)
         x = np.asarray(img, dtype=np.float32) / 255.0
         x = x.transpose(2, 0, 1)[None, ...]
         y = _session.run(None, {"input": x})[0][0]
@@ -42,7 +73,7 @@ def extract_tags(path: Path, threshold: float = 0.35) -> Dict[str, float]:
                 t = tag.replace("_", " ")
                 out[t] = s
         return out
-    except Exception as exc:
+    except Exception as exc:  # pragma: no cover - inference failures
         logger.warning("WD14 inference failed: %s", exc, exc_info=True)
         return {}
 


### PR DESCRIPTION
## Summary
- Add automatic download and robust preprocessing for WD14 ONNX tagger
- Expand CLIP Interrogator to surface fallback lighting phrases and counts
- Harden palette extraction and ensure prompts and debug info stay populated

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68adfd6a9934832887033c9e29b63a32