### PR TITLE
Improve tag extraction robustness and prompt safety

### DIFF
--- a/img2prompt/assemble/palette.py
+++ b/img2prompt/assemble/palette.py
@@ -36,5 +36,11 @@ def extract_palette(path: Path, colors: int = 5) -> List[str]:
         return cleaned[:colors]
     except Exception as exc:  # pragma: no cover - fallback path
         logger.warning("Palette extraction failed: %s", exc, exc_info=True)
-        fallback = ["#2a3d6d", "#dcb187", "#a56c4a", "#f2d6b0", "#1c1c1c"]
+        fallback = [
+            "#2a3d6d",
+            "#ddc6ae",
+            "#a5806c",
+            "#5c4032",
+            "#2c455b",
+        ]
         return fallback[:colors]

--- a/img2prompt/assemble/style.py
+++ b/img2prompt/assemble/style.py
@@ -24,7 +24,15 @@ ANIME_PARAMS = {
 def determine_style(ci_text: str) -> Tuple[str, Dict[str, float]]:
     """Classify style as 'anime' or 'photo' from CLIP Interrogator text."""
 
-    cues = ["35mm", "film grain", "bokeh", "studio light", "natural light", "cinematic"]
+    cues = [
+        "35mm",
+        "film grain",
+        "bokeh",
+        "studio light",
+        "natural light",
+        "cinematic",
+        "photograph",
+    ]
     text = ci_text.lower()
     if any(c in text for c in cues):
         return "photo", PHOTO_PARAMS.copy()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,7 +29,7 @@ def test_cli_generates_clean_output(tmp_path, monkeypatch):
 
     dd_tags = {alpha_tag(i): 1.0 for i in range(20, 40)}
     dd_tags["subject_extra_1"] = 0.9
-    monkeypatch.setattr(cli.deepdanbooru, "extract_tags", lambda p: dd_tags)
+    monkeypatch.setattr(cli.deepdanbooru, "extract_tags", lambda p: (dd_tags, None))
 
     ci_tags = {alpha_tag(i): 0.5 for i in range(40, 80)}
     ci_tags["extra_tag_1"] = 0.8
@@ -85,7 +85,7 @@ def test_cli_handles_deepdanbooru_failure(tmp_path, monkeypatch):
     monkeypatch.setattr(cli.wd14_onnx, "extract_tags", lambda p: wd_tags)
 
     def dd_fail(p):
-        raise RuntimeError("tensorflow_io missing")
+        return {}, "tensorflow_io missing"
 
     monkeypatch.setattr(cli.deepdanbooru, "extract_tags", dd_fail)
 


### PR DESCRIPTION
## Summary
- Filter WD14 tags by category and lower threshold to include more non-character tags
- Gracefully degrade DeepDanbooru extraction and propagate errors without failing the pipeline
- Enhance prompt assembly with stronger name filtering, richer fallbacks, and updated style/palette cues

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae5b9731fc8328b5b7fc8749d2ad81