### PR TITLE
Handle optional dependencies in tag extractors

### DIFF
--- a/img2prompt/extract/deepdanbooru.py
+++ b/img2prompt/extract/deepdanbooru.py
@@ -30,7 +30,12 @@ def extract_tags(path: Path, threshold: float = 0.35) -> Tuple[Dict[str, float],
         _load()
     except Exception as exc:  # pragma: no cover - load failures
         logger.warning("DeepDanbooru load failed: %s", exc, exc_info=True)
-        return {}, str(exc)
+        msg = (
+            "tensorflow_io missing"
+            if isinstance(exc, ModuleNotFoundError) and "tensorflow_io" in str(exc)
+            else str(exc)
+        )
+        return {}, msg
 
     if _model is None or _tags is None:
         return {}, "DeepDanbooru model unavailable"

--- a/img2prompt/extract/wd14_onnx.py
+++ b/img2prompt/extract/wd14_onnx.py
@@ -6,9 +6,13 @@ import csv
 import shutil
 
 import numpy as np
-import onnxruntime as ort
 from PIL import Image
 from huggingface_hub import hf_hub_download
+
+try:  # pragma: no cover - optional dependency for tests
+    import onnxruntime as ort
+except Exception:  # pragma: no cover - handled gracefully at runtime
+    ort = None  # type: ignore
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +47,9 @@ def _load() -> None:
     if _session is not None and _tags is not None:
         return
     try:
+        if ort is None:
+            raise RuntimeError("onnxruntime not installed")
+
         bases = [
             Path(__file__).resolve().parent / "models",
             Path.cwd() / "models",


### PR DESCRIPTION
## Summary
- Make ONNXRuntime import optional in `wd14_onnx` and raise clear error when missing
- Return a concise `tensorflow_io missing` message when DeepDanbooru dependencies are absent

## Testing
- `pip install onnxruntime -q` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae5df50ce08328836d087f7a88a24b