### PR TITLE
Improve tag processing and photo style bias

### DIFF
--- a/img2prompt/cli.py
+++ b/img2prompt/cli.py
@@ -39,12 +39,12 @@ def run(image_path: str) -> Path:
         tags_debug["deepdanbooru"] = {"count": 0, "ok": False, "error": str(exc)}
 
     try:
-        ci_tags_raw, ci_picks, ci_raw = clip_interrogator.extract_tags(image_path)
-        ci_tags = normalize.remove_placeholders(ci_tags_raw)
+        ci_tags, ci_picks, ci_raw = clip_interrogator.extract_tags(image_path)
+        ci_tags = normalize.remove_placeholders(ci_tags)
         tags_debug["clip_interrogator"] = {"count": len(ci_tags), "ok": True}
     except Exception as exc:  # pragma: no cover - should be rare
         logger.warning("CLIP Interrogator extractor failed: %s", exc, exc_info=True)
-        ci_tags, ci_picks, ci_text = {}, [], ""
+        ci_tags, ci_picks, ci_raw = {}, [], ""
         tags_debug["clip_interrogator"] = {
             "count": 0,
             "ok": False,
@@ -69,7 +69,7 @@ def run(image_path: str) -> Path:
     prompt_tags = clean_tokens(prompt_tags)
     prompt = ", ".join(prompt_tags)
 
-    style_name, params = style.determine_style(ci_raw)
+    style_name, params = style.determine_style(ci_raw, wd_tags)
 
     print(
         f"[DEBUG] wd14={len(wd_tags)}, dd={len(dd_tags)}, ci={len(ci_tags)}, "

--- a/img2prompt/utils/text_filters.py
+++ b/img2prompt/utils/text_filters.py
@@ -6,10 +6,10 @@ BAD_TOKENS = {"ayami", "kojima", "tsugumi", "ohba", "murata", "kohei"}
 
 
 def clean_tokens(tokens):
-    out = []
+    out, seen = [], set()
     for t in tokens:
-        t = t.strip(", ").lower()
-        if not t or len(t) < 2 or len(t) > 40:
+        t = (t or "").strip(", ").lower()
+        if not (2 <= len(t) <= 40):
             continue
         if NAME_PAT.search(t):
             continue
@@ -17,12 +17,8 @@ def clean_tokens(tokens):
             continue
         if any(bt in t for bt in BAD_TOKENS):
             continue
-        out.append(t)
-    seen = set()
-    dedup = []
-    for t in out:
         if t not in seen:
             seen.add(t)
-            dedup.append(t)
-    return dedup
+            out.append(t)
+    return out
 

--- a/tests/test_style_picker.py
+++ b/tests/test_style_picker.py
@@ -10,14 +10,14 @@ from img2prompt.assemble import style
 
 def test_determine_style_photo_params():
     ci_text = "a photo with bokeh and 35mm film grain"
-    result, params = style.determine_style(ci_text)
+    result, params = style.determine_style(ci_text, {})
     assert result == "photo"
     assert params == style.PHOTO_PARAMS
 
 
 def test_determine_style_anime_params():
     ci_text = "an illustration of a cat"
-    result, params = style.determine_style(ci_text)
+    result, params = style.determine_style(ci_text, {"anime": 0.9})
     assert result == "anime"
     assert params == style.ANIME_PARAMS
 

--- a/tests/test_wd14_postprocess.py
+++ b/tests/test_wd14_postprocess.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+
+from img2prompt.extract import wd14_onnx
+
+
+def test_postprocess_filters_numeric_and_character(monkeypatch):
+    # Setup dummy names and categories
+    names = ["123", "some_character", "valid_tag"]
+    cats = ["general", "character", "general"]
+    scores = np.array([0.9, 0.8, 0.95])
+    monkeypatch.setattr(wd14_onnx, "_names", names)
+    monkeypatch.setattr(wd14_onnx, "_cats", cats)
+    result = wd14_onnx._postprocess_wd14(scores, threshold=0.25)
+    assert result == {"valid tag": 0.95}


### PR DESCRIPTION
## Summary
- Keep CLIP Interrogator raw text and picks for later stages and use WD14 tags to influence style
- Bias style selection towards photo based on CI text with WD14 fallback
- Filter out names and numeric tokens in final prompt list and add test for WD14 post-processing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae69642f6c83288cafd536b821ef7d