### PR TITLE
Improve token filtering and default photo style

### DIFF
--- a/img2prompt/assemble/style.py
+++ b/img2prompt/assemble/style.py
@@ -25,7 +25,7 @@ ANIME_PARAMS = {
 def determine_style(ci_raw: str, wd14_tags: Dict[str, float]) -> Tuple[str, Dict[str, float]]:
     ci_low = (ci_raw or "").lower()
     anime_hits = sum(
-        k in ci_low for k in ["anime", "manga", "comic", "cartoon", "cel shading", "illustration"]
+        k in ci_low for k in ["anime", "manga", "comic", "cartoon", "cel shading"]
     )
     photo_hits = sum(
         k in ci_low
@@ -42,17 +42,10 @@ def determine_style(ci_raw: str, wd14_tags: Dict[str, float]) -> Tuple[str, Dict
         ]
     )
 
-    if anime_hits > photo_hits:
+    if anime_hits >= 2 and photo_hits == 0:
         style = "anime"
-    elif photo_hits > anime_hits:
-        style = "photo"
     else:
-        # WD14補助：アニメ強語が多いか
-        wd14_join = " ".join(wd14_tags.keys())
-        anime_present = any(
-            k in wd14_join for k in ["anime", "manga", "comic", "cartoon", "illustration"]
-        )
-        style = "anime" if anime_present else "photo"
+        style = "photo"
 
     params = PHOTO_PARAMS if style == "photo" else ANIME_PARAMS
     return style, params

--- a/img2prompt/cli.py
+++ b/img2prompt/cli.py
@@ -67,14 +67,18 @@ def run(image_path: str) -> Path:
 
     merged_before = ordered
     prompt_tags = clean_tokens(merged_before)
-    prompt_tags_final = bucketize.ensure_50_70(prompt_tags, caption, ci_picks)
-    prompt = ", ".join(prompt_tags_final)
+    after_clean = len(prompt_tags)
+    prompt_tags = bucketize.ensure_50_70(
+        prompt_tags, caption, ci_picks, min_total=55, max_total=70
+    )
+    final_count = len(prompt_tags)
+    prompt = ", ".join(prompt_tags)
 
     style_name, params = style.determine_style(ci_raw, wd14_tags)
 
     print(
         f"[DEBUG] wd14_raw={len(wd14_tags_raw)} -> wd14_clean={len(wd14_tags)}; ci_raw_picks={len(ci_picks)}; "
-        f"merged_before={len(merged_before)}; after_clean={len(prompt_tags)}; final={len(prompt_tags_final)}; style={style_name}"
+        f"merged_before={len(merged_before)}; after_clean={after_clean}; final={final_count}; style={style_name}"
     )
 
     data = {

--- a/img2prompt/utils/text_filters.py
+++ b/img2prompt/utils/text_filters.py
@@ -1,63 +1,71 @@
 import re
 import unicodedata
 
-# OCRで空白が割れた例: "koj ima" もヒットさせる
-NAME_TWO_WORDS = re.compile(r"\b[a-z]{2,}\s+[a-z]{2,}\b", re.I)
+# TitleCase の姓名だけを人名とみなす（写真語 "upper body" 等を誤排除しない）
+NAME_TITLECASE = re.compile(r"\b[A-Z][a-z]{2,}\s+[A-Z][a-z]{2,}\b")
+
 NUMERIC_PAT = re.compile(r"^\d+$")
 
-# アーティスト系の代表語（必要最小限）──厳格一致と「空白を詰めた一致」の両方で弾く
+# 既知のアーティスト名（最小限）
 ARTIST_TOKENS = {
-    "ayami kojima","rei hiroe","shiori teshirogi","tsugumi ohba","tsukasa dokite",
-    "omina tachibana","kohei murata","ayami","kojima","ohba","murata","teshirogi","hiroe",
+    "Ayami Kojima","Rei Hiroe","Shiori Teshirogi","Tsugumi Ohba",
+    "Tsukasa Dokite","Omina Tachibana","Kohei Murata",
+    "Ayami","Kojima","Ohba","Murata","Teshirogi","Hiroe",
 }
 
-def _squash_spaces(s: str) -> str:
-    # 連続空白を1つに、さらに空白削除版も返す
-    s_norm = " ".join(s.split())
-    return s_norm, s_norm.replace(" ", "")
-
-def _normalize(s: str) -> str:
-    s = unicodedata.normalize("NFKC", s)
-    return s.strip(" ,.;:").lower()
-
-def is_artist_like(tok: str) -> bool:
-    t = _normalize(tok)
-    t_space, t_nospace = _squash_spaces(t)
-    # 厳格一致
-    if t_space in ARTIST_TOKENS or t in ARTIST_TOKENS:
-        return True
-    # "koj ima" → "kojima" のような分割空白も落とす
-    for a in ARTIST_TOKENS:
-        a_space, a_nospace = _squash_spaces(a)
-        if t_nospace == a_nospace:
-            return True
-    # 2語の姓名パターンは原則除外（例外を許したければここでホワイトリスト）
-    if NAME_TWO_WORDS.search(t):
-        return True
-    return False
-
-# アニメ/線画系・数え上げタグなどを落とす（サブストリングでOK）
+# 線画/アニメ系の“除外候補”（サブストリングOK）
 BAN_SUBSTR = {
-    "1girl","1boy","solo","comic","manga","cartoon","lineart","sketch","monochrome",
-    "grayscale","greyscale","sensitive","dated","general",
+    "1girl","1boy","solo","comic","manga","cartoon","lineart","sketch",
+    "monochrome","grayscale","greyscale","sensitive"
 }
 
-def is_banned_semantics(tok: str) -> bool:
-    t = _normalize(tok)
-    return any(b in t for b in BAN_SUBSTR)
+# 写真系の“二語フレーズ”は明示ホワイトリストで必ず通す
+SAFE_TWO_WORDS = {
+    "upper body","soft lighting","warm tones","sharp focus","depth of field",
+    "wooden interior","window light","cozy atmosphere","warm highlights",
+    "gentle shadow","natural skin","ambient light","balanced composition",
+    "eye level","soft contrast","realistic texture","color palette",
+    "fine details","cinematic feel","subtle bokeh","clean background",
+    "subtle shadows","smooth gradients","natural highlights","muted colors",
+    "shallow depth","soft focus"
+}
+
+def _nfkc_lower(s: str) -> str:
+    return unicodedata.normalize("NFKC", s).strip(" ,.;:").lower()
+
+def _is_artist_like(raw: str) -> bool:
+    # 空白を詰めた比較で OCR 崩れにも耐性
+    raw_nfkc = unicodedata.normalize("NFKC", raw).strip()
+    nospace = raw_nfkc.replace(" ", "")
+    for a in ARTIST_TOKENS:
+        if raw_nfkc == a or nospace == a.replace(" ", ""):
+            return True
+    # TitleCase 姓名のみ人名判定（lower化後の二語は弾かない）
+    return NAME_TITLECASE.search(raw) is not None
 
 def clean_tokens(tokens):
     out, seen = [], set()
     for raw in tokens:
-        t = _normalize(raw)
-        if not (2 <= len(t) <= 40):  # 極端に短い/長い
+        if not raw: 
             continue
-        if NUMERIC_PAT.match(t):     # 純数値
+        # ホワイトリスト先行：写真系二語は無条件で通す
+        if _nfkc_lower(raw) in SAFE_TWO_WORDS:
+            t = _nfkc_lower(raw)
+            if t not in seen:
+                seen.add(t); out.append(t)
             continue
-        if is_artist_like(t):        # 人名/作家名/OCR崩れ
+
+        # 通常チェック
+        if _is_artist_like(raw):              # 人名/作家名（TitleCase）除外
             continue
-        if is_banned_semantics(t):   # アニメ/線画/列挙ノイズ
+        t = _nfkc_lower(raw)
+        if not (2 <= len(t) <= 40):           # 極端に短長は除外
             continue
+        if NUMERIC_PAT.match(t):              # 純数値は除外
+            continue
+        if any(b in t for b in BAN_SUBSTR):   # 線画/アニメ系ノイズ
+            continue
+
         if t not in seen:
             seen.add(t); out.append(t)
     return out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,7 +49,7 @@ def test_cli_generates_clean_output(tmp_path, monkeypatch):
     data = json.loads(Path(out).read_text("utf-8"))
 
     tags = [t.strip() for t in data["prompt"].split(",") if t.strip()]
-    assert 50 <= len(tags) <= 70
+    assert 55 <= len(tags) <= 70
     assert all(
         not t.startswith("subject_extra_") and not t.startswith("extra_tag_")
         for t in tags

--- a/tests/test_style_picker.py
+++ b/tests/test_style_picker.py
@@ -16,8 +16,8 @@ def test_determine_style_photo_params():
 
 
 def test_determine_style_anime_params():
-    ci_text = "an illustration of a cat"
-    result, params = style.determine_style(ci_text, {"anime": 0.9})
+    ci_text = "an anime manga character"
+    result, params = style.determine_style(ci_text, {})
     assert result == "anime"
     assert params == style.ANIME_PARAMS
 


### PR DESCRIPTION
## Summary
- Clean tokens by dropping only TitleCase names while whitelisting common two-word photo phrases
- Require at least 55 tags via post-cleanup completion and default style to photo unless anime clues dominate
- Update tests for new minimum tag count and stricter anime style detection

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae855b5e548328b058f415bae5498a