### PR TITLE
feat: refine text token filters

### DIFF
--- a/tests/test_text_filters.py
+++ b/tests/test_text_filters.py
@@ -9,20 +9,56 @@ sys.path.append(str(ROOT))
 from img2prompt.utils.text_filters import clean_tokens
 
 
-def test_clean_tokens_drops_meta_and_counts():
+def test_clean_tokens_filters_noise_and_meta():
     tokens = [
         "Artist Name",
         "soft lighting",
         "beautiful japanese girls face",
-        "standing",
+        "twitter username",
         "1girl",
         "1boy",
         "solo",
         "General",
+        "dated",
         "valid token",
     ]
     out = clean_tokens(tokens)
     assert "soft lighting" in out
     assert "valid token" in out
-    banned = {"artist name", "beautiful japanese girls face", "standing", "1girl", "1boy", "solo", "general"}
+    banned = {
+        "artist name",
+        "beautiful japanese girls face",
+        "twitter username",
+        "1girl",
+        "1boy",
+        "solo",
+        "general",
+        "dated",
+    }
     assert not any(b in out for b in banned)
+
+
+def test_clean_tokens_strips_artist_names_case_insensitive():
+    tokens = [
+        "Ayami Kojima",
+        "ayami kojima",
+        "Makoto Shinkai",
+        "soft lighting",
+    ]
+    out = clean_tokens(tokens)
+    assert out == ["soft lighting"]
+
+
+def test_clean_tokens_unifies_background_tags():
+    tokens = [
+        "white background",
+        "grey background",
+        "simple background",
+        "clean background",
+        "soft lighting",
+    ]
+    out = clean_tokens(tokens)
+    backgrounds = [t for t in out if "background" in t]
+    assert backgrounds == ["white background"]
+    assert "soft lighting" in out
+


### PR DESCRIPTION
## Summary
- expand artist and human name detection to handle lowercase and known variations
- drop additional meta phrases and merge conflicting background tags
- cover new filtering rules with dedicated tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae8f2ffc3883288140622b3391b9dc