### PR TITLE
Improve prompt text filters

### DIFF
--- a/tests/test_text_filters.py
+++ b/tests/test_text_filters.py
@@ -18,6 +18,10 @@ def test_clean_tokens_filters_noise_and_meta():
         "1girl",
         "1boy",
         "solo",
+        "standing",
+        "text focus",
+        "no humans",
+        "multiple girls",
         "General",
         "dated",
         "valid token",
@@ -32,6 +36,10 @@ def test_clean_tokens_filters_noise_and_meta():
         "1girl",
         "1boy",
         "solo",
+        "standing",
+        "text focus",
+        "no humans",
+        "multiple girls",
         "general",
         "dated",
     }
@@ -43,6 +51,16 @@ def test_clean_tokens_strips_artist_names_case_insensitive():
         "Ayami Kojima",
         "ayami kojima",
         "Makoto Shinkai",
+        "soft lighting",
+    ]
+    out = clean_tokens(tokens)
+    assert out == ["soft lighting"]
+
+
+def test_clean_tokens_filters_typos_in_artist_names():
+    tokens = [
+        "ayami koj ima",
+        "matoko shinkai",
         "soft lighting",
     ]
     out = clean_tokens(tokens)


### PR DESCRIPTION
## Summary
- Detect artist names more robustly using NFKC normalization and a small Levenshtein distance
- Expand filtering for meta/positional tags and allow only a single background tag
- Add regression tests covering new text filter behaviors

## Testing
- `python -m pytest tests/test_text_filters.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae9f91e5a483289b8c1e2b5b066bfa