### PR TITLE
Handle single-name artists and dedupe background tags

### DIFF
--- a/img2prompt/cli.py
+++ b/img2prompt/cli.py
@@ -4,7 +4,7 @@ import logging
 
 from .extract import blip, clip_interrogator, deepdanbooru, wd14_onnx
 from .assemble import normalize, bucketize, palette, style
-from .utils.text_filters import clean_tokens
+from .utils.text_filters import clean_tokens, dedupe_background
 from .options.style_presets import apply_style, STYLE_PRESETS
 from .export import writer
 
@@ -72,6 +72,7 @@ def run(image_path: str, style_preset: str | None = None) -> Path:
     prompt_tags = bucketize.ensure_50_70(
         prompt_tags, caption, ci_picks, min_total=55, max_total=70
     )
+    prompt_tags = dedupe_background(prompt_tags)
     final_count = len(prompt_tags)
     if style_preset:
         prompt_tags = apply_style(prompt_tags, style_preset)

--- a/img2prompt/utils/text_filters.py
+++ b/img2prompt/utils/text_filters.py
@@ -8,7 +8,10 @@ NUMERIC_PAT = re.compile(r"^\d+$")
 ARTIST_TOKENS = {
     "Ayami Kojima","Rei Hiroe","Shiori Teshirogi","Tsugumi Ohba",
     "Tsukasa Dokite","Omina Tachibana","Kohei Murata",
-    "Makoto Shinkai","Erika Ikuta","Harumi"
+    "Makoto Shinkai","Erika Ikuta","Harumi",
+    # 単語（小文字化比較で弾く）
+    "Ayami","Kojima","Ohba","Teshirogi","Hiroe",
+    "Dokite","Tachibana","Ikuta","Shinkai",
 }
 # 小文字・空白除去済みの比較セット
 _ART_LOWER_NOWS = {
@@ -119,5 +122,17 @@ def clean_tokens(tokens):
         if t not in seen:
             seen.add(t); out.append(t)
 
+    return out
+
+
+def dedupe_background(tags):
+    out = []
+    seen_bg = False
+    for t in tags:
+        if "background" in t:
+            if seen_bg:
+                continue
+            seen_bg = True
+        out.append(t)
     return out
 

--- a/tests/test_text_filters.py
+++ b/tests/test_text_filters.py
@@ -6,7 +6,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
-from img2prompt.utils.text_filters import clean_tokens
+from img2prompt.utils.text_filters import clean_tokens, dedupe_background
 
 
 def test_clean_tokens_filters_noise_and_meta():
@@ -79,4 +79,16 @@ def test_clean_tokens_unifies_background_tags():
     backgrounds = [t for t in out if "background" in t]
     assert backgrounds == ["white background"]
     assert "soft lighting" in out
+
+
+def test_clean_tokens_filters_single_name_tokens():
+    tokens = ["ayami", "shinkai", "soft lighting"]
+    out = clean_tokens(tokens)
+    assert out == ["soft lighting"]
+
+
+def test_dedupe_background_removes_extra_backgrounds():
+    tags = ["white background", "clean background", "soft lighting"]
+    out = dedupe_background(tags)
+    assert out == ["white background", "soft lighting"]
 


### PR DESCRIPTION
## Summary
- filter single-token artist names
- remove duplicate background tags after bucketizing
- test text filtering and background dedupe

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aea149dae083288bc6e63c54cffc4d