### PR TITLE
Refine text filtering and artist detection

### DIFF
--- a/tests/test_text_filters.py
+++ b/tests/test_text_filters.py
@@ -19,11 +19,9 @@ def test_clean_tokens_filters_noise_and_meta():
         "1boy",
         "solo",
         "standing",
-        "text focus",
-        "no humans",
-        "multiple girls",
         "General",
         "dated",
+        "negative space",
         "valid token",
     ]
     out = clean_tokens(tokens)
@@ -37,11 +35,9 @@ def test_clean_tokens_filters_noise_and_meta():
         "1boy",
         "solo",
         "standing",
-        "text focus",
-        "no humans",
-        "multiple girls",
         "general",
         "dated",
+        "negative space",
     }
     assert not any(b in out for b in banned)
 


### PR DESCRIPTION
## Summary
- Simplify artist-name detection with minimal Levenshtein distance (<=1) and dedupe logic
- Whitelist photography-related tokens while filtering anime/meta noise
- Ensure background tags are unique after tag completion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aea48968e08328a9e359cf781fdab7