### PR TITLE
Unify token safety check and enforce background limit in tag completion

### DIFF
--- a/img2prompt/cli.py
+++ b/img2prompt/cli.py
@@ -6,7 +6,6 @@ from .extract import blip, clip_interrogator, deepdanbooru, wd14_onnx
 from .assemble import normalize, bucketize, palette, style
 from .utils.text_filters import (
     clean_tokens,
-    dedupe_background,
     is_bad_token,
     normalize_terms,
 )
@@ -82,7 +81,6 @@ def run(image_path: str, style_preset: str | None = None) -> Path:
         max_total=70,
         allow=lambda w: not is_bad_token(w),
     )
-    prompt_tags = dedupe_background(prompt_tags)
     prompt_tags = normalize_terms(prompt_tags)
     final_count = len(prompt_tags)
     if style_preset:

--- a/img2prompt/utils/text_filters.py
+++ b/img2prompt/utils/text_filters.py
@@ -136,7 +136,13 @@ def dedupe_background(tags):
 
 
 def is_bad_token(raw: str) -> bool:
+    """補完時にも再利用できる禁止語判定。まず“安全語は常に許可”。"""
     t = _nfkc_lower(raw or "")
+    # ✅ 先にホワイトリスト優先
+    if (t in SAFE_EXACT) or any(k in t for k in SAFE_SUBSTR):
+        return False
+
+    # ❌ 通常のNG判定
     if not (2 <= len(t) <= 40):
         return True
     if NUMERIC_PAT.match(t):

--- a/tests/test_bucketize.py
+++ b/tests/test_bucketize.py
@@ -21,3 +21,20 @@ def test_bucketize_word_count_and_no_duplicates():
     assert 50 <= total <= 70
     all_tags = [t for bucket in buckets.values() for t in bucket]
     assert len(all_tags) == len(set(all_tags))
+
+
+def test_ensure_50_70_respects_allow_and_background():
+    from img2prompt.utils.text_filters import is_bad_token
+
+    tags = ["soft lighting", "1girl", "white background", "black background"]
+    out = bucketize.ensure_50_70(
+        tags,
+        caption="",
+        ci_picks=[],
+        min_total=0,
+        max_total=10,
+        allow=lambda w: not is_bad_token(w),
+    )
+    assert "1girl" not in out
+    backgrounds = [t for t in out if "background" in t]
+    assert backgrounds == ["white background"]

--- a/tests/test_text_filters.py
+++ b/tests/test_text_filters.py
@@ -6,7 +6,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 
-from img2prompt.utils.text_filters import clean_tokens, dedupe_background
+from img2prompt.utils.text_filters import clean_tokens, dedupe_background, is_bad_token
 
 
 def test_clean_tokens_filters_noise_and_meta():
@@ -87,4 +87,11 @@ def test_dedupe_background_removes_extra_backgrounds():
     tags = ["white background", "clean background", "soft lighting"]
     out = dedupe_background(tags)
     assert out == ["white background", "soft lighting"]
+
+
+def test_is_bad_token_handles_whitelist_and_bans():
+    assert is_bad_token("1girl")
+    assert is_bad_token("Makoto Shinkai")
+    assert is_bad_token("123")
+    assert not is_bad_token("soft lighting")
 


### PR DESCRIPTION
## Summary
- centralize token safety logic in `is_bad_token`, allowing whitelist override before bans
- enhance `ensure_50_70` with an `allow` hook and single-background enforcement
- simplify CLI tag flow to use unified safety filter

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aeab142de08328a17ede5904abfdfd