### PR TITLE
Add unified token filtering and safe prompt finalization

### DIFF
--- a/img2prompt/assemble/bucketize.py
+++ b/img2prompt/assemble/bucketize.py
@@ -144,6 +144,7 @@ def ensure_50_70(
     merged: List[str] = []
     seen: set[str] = set()
     bg_kept = False
+    blocked: list[str] = []
 
     def add_many(src: List[str] | None, limit: int | None = None) -> None:
         nonlocal bg_kept
@@ -156,10 +157,12 @@ def ensure_50_70(
                 if bg_kept:
                     continue
                 if not allow(w):
+                    blocked.append(w)
                     continue
                 bg_kept = True
             else:
                 if not allow(w):
+                    blocked.append(w)
                     continue
             merged.append(w)
             seen.add(w)
@@ -175,4 +178,5 @@ def ensure_50_70(
         add_many(FLOOR, min_total)
     if len(merged) < min_total:
         add_many(FILLER_BANK, min_total)
+    print(f"[DEBUG] blocked_in_ensure={blocked[:10]} (+{max(0, len(blocked) - 10)} more)")
     return merged[:max_total]

--- a/img2prompt/cli.py
+++ b/img2prompt/cli.py
@@ -8,6 +8,8 @@ from .utils.text_filters import (
     clean_tokens,
     is_bad_token,
     normalize_terms,
+    dedupe_background,
+    finalize_prompt_safe,
 )
 from .options.style_presets import apply_style, STYLE_PRESETS
 from .export import writer
@@ -82,6 +84,8 @@ def run(image_path: str, style_preset: str | None = None) -> Path:
         allow=lambda w: not is_bad_token(w),
     )
     prompt_tags = normalize_terms(prompt_tags)
+    prompt_tags = dedupe_background(prompt_tags)
+    prompt_tags = finalize_prompt_safe(prompt_tags, min_total=55, max_total=70)
     final_count = len(prompt_tags)
     if style_preset:
         prompt_tags = apply_style(prompt_tags, style_preset)

--- a/tests/test_bucketize.py
+++ b/tests/test_bucketize.py
@@ -38,3 +38,20 @@ def test_ensure_50_70_respects_allow_and_background():
     assert "1girl" not in out
     backgrounds = [t for t in out if "background" in t]
     assert backgrounds == ["white background"]
+
+
+def test_is_bad_token_meta_exact_and_finalize():
+    from img2prompt.utils.text_filters import (
+        is_bad_token,
+        finalize_prompt_safe,
+        SAFE_FILL,
+    )
+
+    for w in ["text focus", "no humans", "multiple girls"]:
+        assert is_bad_token(w)
+
+    # ensure finalize fills with safe tokens only
+    base = ["portrait"]
+    out = finalize_prompt_safe(base.copy(), min_total=5, max_total=10)
+    assert len(out) >= 5
+    assert all(t in SAFE_FILL or t == "portrait" for t in out)


### PR DESCRIPTION
## Summary
- Factor out `is_bad_token` for shared blacklist/whitelist logic and expand META_EXACT to block stray meta tags
- Extend `ensure_50_70` with allow hook, debug logging, and background checks
- Introduce safe filler list and `finalize_prompt_safe` and wire into CLI processing

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aeadae1320832898ea36e87e344a20