### PR TITLE
Enhance artist token filtering

### DIFF
--- a/tests/test_text_filters.py
+++ b/tests/test_text_filters.py
@@ -57,6 +57,7 @@ def test_clean_tokens_filters_typos_in_artist_names():
     tokens = [
         "ayami koj ima",
         "matoko shinkai",
+        "deayami kojima",
         "soft lighting",
     ]
     out = clean_tokens(tokens)


### PR DESCRIPTION
## Summary
- tighten artist name detection by checking full/first/last name tokens and allowing small typos
- cover deformed artist names in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeb0a541c4832884a98962825717a5