### PR TITLE
Remove stray artist name fragments

### DIFF
--- a/tests/test_text_filters.py
+++ b/tests/test_text_filters.py
@@ -84,10 +84,10 @@ def test_clean_tokens_unifies_background_tags():
     assert "soft lighting" in out
 
 
-def test_clean_tokens_allows_single_name_tokens():
+def test_clean_tokens_strips_single_name_tokens():
     tokens = ["ayami", "shinkai", "soft lighting"]
     out = clean_tokens(tokens)
-    assert out == ["ayami", "shinkai", "soft lighting"]
+    assert out == ["soft lighting"]
 
 
 def test_dedupe_background_removes_extra_backgrounds():


### PR DESCRIPTION
## Summary
- add `purge_artist_fragments` to strip residual artist name parts and integrate into `finalize_pipeline`
- extend `_looks_like_artist` to reject single-word first/last names
- adjust tests for new single-name filtering

## Testing
- `python - <<'PY'
from img2prompt.utils.text_filters import finalize_pipeline
blocked = {
    "ayami koj ima","deayami kojima","matoko shinkai","tsugumi ohba","erika ikuta",
    "tsukasa dokite","rei hiroe","omina tachibana","shiori teshirogi"
}
sample = ["portrait","ayami","clean background","looking at camera","short hair","long hair"]
out = finalize_pipeline(sample, blocked_names=blocked)
print("len:", len(out))
print("contains 'ayami'?:", any(t.lower()=="ayami" for t in out))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aefe5820c08328a0e9fb10fedf4ee9