### PR TITLE
Filter invisible garments and resolve eye-mouth conflicts

### DIFF
--- a/img2prompt/extract/deepdanbooru.py
+++ b/img2prompt/extract/deepdanbooru.py
@@ -15,7 +15,12 @@ def _load() -> None:
     global _model, _tags
     if _model is not None and _tags is not None:
         return
-    import deepdanbooru as dd  # type: ignore
+    try:
+        import deepdanbooru as dd  # type: ignore
+    except ImportError:
+        logger.info("[deepdanbooru] disabled")
+        _model = _tags = None
+        return
 
     project_path = dd.project.default_project_path()
     _model = dd.project.load_model_from_project(project_path)
@@ -38,7 +43,7 @@ def extract_tags(path: Path, threshold: float = 0.35) -> Tuple[Dict[str, float],
         return {}, msg
 
     if _model is None or _tags is None:
-        return {}, "DeepDanbooru model unavailable"
+        return {}, None
 
     try:
         from PIL import Image

--- a/tests/test_text_filters.py
+++ b/tests/test_text_filters.py
@@ -104,12 +104,22 @@ def test_is_bad_token_handles_whitelist_and_bans():
 
 
 def test_drop_contradictions_removes_conflicting_tags():
-    tags = ["long hair", "short hair", "soft lighting", "open mouth", "closed mouth"]
+    tags = [
+        "long hair",
+        "short hair",
+        "smile",
+        "closed mouth",
+        "looking at camera",
+        "closed eyes",
+        "soft lighting",
+    ]
     out = drop_contradictions(tags)
     assert "long hair" not in out
     assert "short hair" not in out
-    assert "open mouth" not in out
     assert "closed mouth" not in out
+    assert "closed eyes" not in out
+    assert "smile" in out
+    assert "looking at camera" in out
     assert "soft lighting" in out
 
 


### PR DESCRIPTION
## Summary
- drop lower-body garment tags when upper-body cues are present
- resolve eye and mouth contradictions during token cleanup
- disable DeepDanbooru gracefully when unavailable

## Testing
- `python - <<'PY'
from img2prompt.utils.text_filters import finalize_pipeline
blk = {"ayami koj ima","matoko shinkai","shiori teshirogi","rei hiroe",
       "omina tachibana","tsugumi ohba","deayami kojima","erika ikuta","tsukasa dokite"}
sample = ["portrait","upper body","skirt","closed eyes","looking at camera","smile",
          "clean background","soft lighting"]
out = finalize_pipeline(sample, blocked_names=blk)
print("len:", len(out), "55-65?", 55 <= len(out) <= 65)
print(out)
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af008f0f248328b5669566085e1edc