### PR TITLE
Normalize background tags and sync captions

### DIFF
--- a/img2prompt/cli.py
+++ b/img2prompt/cli.py
@@ -8,6 +8,7 @@ from .utils.text_filters import (
     clean_tokens,
     is_bad_token,
     finalize_pipeline,
+    sync_caption_to_prompt,
 )
 from .options.style_presets import apply_style, STYLE_PRESETS
 from .export import writer
@@ -81,13 +82,12 @@ def run(image_path: str, style_preset: str | None = None) -> Path:
         max_total=70,
         allow=lambda w: not is_bad_token(w),
     )
-    prompt_tags = finalize_pipeline(prompt_tags)
-    final_count = len(prompt_tags)
     if style_preset:
         prompt_tags = apply_style(prompt_tags, style_preset)
-        if len(prompt_tags) > 70:
-            prompt_tags = prompt_tags[:70]
+    prompt_tags = finalize_pipeline(prompt_tags)
+    final_count = len(prompt_tags)
     prompt = ", ".join(prompt_tags)
+    caption = sync_caption_to_prompt(caption, prompt_tags)
 
     style_name, params = style.determine_style(ci_raw, wd14_tags)
 


### PR DESCRIPTION
## Summary
- unify background-related tags under `clean background` and drop conflicting prompt terms
- resolve framing/focus/aperture contradictions and avoid filler conflicts
- trim caption objects not present in prompt

## Testing
- `pytest -q`
- `python - <<'PY'
from img2prompt.utils.text_filters import finalize_pipeline, sync_caption_to_prompt
blk = {"ayami koj ima","matoko shinkai","shiori teshirogi","rei hiroe",
       "omina tachibana","tsugumi ohba","deayami kojima","erika ikuta","tsukasa dokite"}

tokens = ["portrait","upper body","soft backdrop","simple backdrop","clean background",
          "tight framing","loose framing","soft focus","sharp focus","wide aperture","narrow aperture",
          "looking at camera","smile","clean background","shallow depth"]

final = finalize_pipeline(tokens, blocked_names=blk)
cap = "a woman sitting at a table with a laptop"
print("final_len:", len(final), "->", 55 <= len(final) <= 65)
print("bg_count:", [t for t in final if 'background' in t or 'backdrop' in t])
print("focus:", [t for t in final if 'focus' in t or 'aperture' in t])
print("framing:", [t for t in final if 'framing' in t or 'composition' in t])
print("caption:", sync_caption_to_prompt(cap, final))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68af034d78fc8328a15b357c921f20bd