### PR TITLE
feat: diversify prompt filler and compress redundancies

### DIFF
--- a/tests/test_bucketize.py
+++ b/tests/test_bucketize.py
@@ -52,6 +52,6 @@ def test_is_bad_token_meta_exact_and_finalize():
 
     # ensure finalize fills with safe tokens only
     base = ["portrait"]
-    out = finalize_prompt_safe(base.copy(), min_total=5, max_total=10)
+    out = finalize_prompt_safe(base.copy(), min_tokens=5, max_tokens=10)
     assert len(out) >= 5
     assert all(t in SAFE_FILL or t == "portrait" for t in out)

--- a/tests/test_text_filters.py
+++ b/tests/test_text_filters.py
@@ -10,6 +10,7 @@ from img2prompt.utils.text_filters import (
     clean_tokens,
     dedupe_background,
     drop_contradictions,
+    compress_redundant,
     finalize_pipeline,
     is_bad_token,
     unify_background,
@@ -178,6 +179,35 @@ def test_unify_background_groups_synonyms():
     out = unify_background(tokens)
     backgrounds = [t for t in out if "background" in t or "backdrop" in t]
     assert backgrounds == ["clean background"]
+
+
+def test_compress_redundant_merges_similar_terms():
+    tokens = [
+        "warm tones",
+        "warm color palette",
+        "soft contrast",
+        "low contrast look",
+        "depth of field",
+        "shallow depth",
+        "subtle bokeh",
+        "creamy bokeh",
+        "balanced composition",
+        "negative space balance",
+        "fine details",
+        "surface detail",
+        "realistic texture",
+        "natural rendition",
+        "clean rendition",
+    ]
+    out = compress_redundant(tokens)
+    assert "warm tones" in out and "warm color palette" not in out
+    assert "soft contrast" in out and "low contrast look" not in out
+    assert "shallow depth" in out and "depth of field" not in out
+    assert "subtle bokeh" in out and "creamy bokeh" not in out
+    assert "balanced composition" in out and "negative space balance" not in out
+    assert "fine details" in out and "surface detail" not in out
+    assert "realistic texture" in out
+    assert "natural rendition" not in out and "clean rendition" not in out
 
 
 def test_sync_caption_to_prompt_removes_unused_objects():


### PR DESCRIPTION
## Summary
- add token compressor to collapse redundant synonyms
- shuffle SAFE_FILL with a context-based seed for more diverse prompt padding
- adjust finalization pipeline to compress then seed-fill prompts

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q`
- `python - <<'PY'
from img2prompt.utils.text_filters import finalize_pipeline
blk = {"ayami koj ima","matoko shinkai","shiori teshirogi","rei hiroe",
       "omina tachibana","tsugumi ohba","deayami kojima","erika ikuta","tsukasa dokite"}

tokens = ["looking at camera","clean background","warm tones","warm color palette",
          "soft contrast","low contrast look","depth of field","shallow depth",
          "subtle bokeh","creamy bokeh","balanced composition","negative space balance",
          "portrait","upper body","soft lighting"]

final = finalize_pipeline(tokens, blocked_names=blk, context=tokens)
print("len:", len(final), "→ 55-65:", 55 <= len(final) <= 65)
print(final[:20])  # 先頭20語レビュー
PY`

------
https://chatgpt.com/codex/tasks/task_e_68af0740de7483288d5d86bff8fcc910