### PR TITLE
Refine caption sync and term compression

### DIFF
--- a/img2prompt/cli.py
+++ b/img2prompt/cli.py
@@ -8,7 +8,6 @@ from .utils.text_filters import (
     clean_tokens,
     is_bad_token,
     finalize_pipeline,
-    sync_caption_to_prompt,
 )
 from .options.style_presets import apply_style, STYLE_PRESETS
 from .export import writer
@@ -84,10 +83,9 @@ def run(image_path: str, style_preset: str | None = None) -> Path:
     )
     if style_preset:
         prompt_tags = apply_style(prompt_tags, style_preset)
-    prompt_tags = finalize_pipeline(prompt_tags)
+    prompt_tags, caption = finalize_pipeline(prompt_tags, caption=caption)
     final_count = len(prompt_tags)
     prompt = ", ".join(prompt_tags)
-    caption = sync_caption_to_prompt(caption, prompt_tags)
 
     style_name, params = style.determine_style(ci_raw, wd14_tags)
 

--- a/tests/test_text_filters.py
+++ b/tests/test_text_filters.py
@@ -195,9 +195,13 @@ def test_compress_redundant_merges_similar_terms():
         "negative space balance",
         "fine details",
         "surface detail",
-        "realistic texture",
+        "photographic realism",
+        "life-like rendering",
         "natural rendition",
         "clean rendition",
+        "gentle shadow",
+        "subtle shadows",
+        "soft shadows",
     ]
     out = compress_redundant(tokens)
     assert "warm tones" in out and "warm color palette" not in out
@@ -206,14 +210,15 @@ def test_compress_redundant_merges_similar_terms():
     assert "subtle bokeh" in out and "creamy bokeh" not in out
     assert "balanced composition" in out and "negative space balance" not in out
     assert "fine details" in out and "surface detail" not in out
-    assert "realistic texture" in out
-    assert "natural rendition" not in out and "clean rendition" not in out
+    assert "photographic realism" in out
+    assert "natural rendition" not in out and "clean rendition" not in out and "life-like rendering" not in out
+    assert "gentle shadow" in out and "subtle shadows" not in out and "soft shadows" not in out
 
 
 def test_sync_caption_to_prompt_removes_unused_objects():
-    caption = "a woman sitting at a table with a laptop and a cup"
+    caption = "a woman sitting at a table with a cup"
     tokens = ["portrait", "clean background"]
     out = sync_caption_to_prompt(caption, tokens)
-    assert "laptop" not in out.lower()
+    assert "table" not in out.lower()
     assert "cup" not in out.lower()
 


### PR DESCRIPTION
## Summary
- compress shadow and realism synonyms to single preferred terms
- expand caption/prompt sync to strip unseen objects and allow table removal
- rerun final prompt compression and sync caption in pipeline and CLI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af0bf7fd18832889a3aeb0f2bbe09c