### PR TITLE
Ensure stable composition and framing

### DIFF
--- a/img2prompt/utils/text_filters.py
+++ b/img2prompt/utils/text_filters.py
@@ -271,6 +271,7 @@ def drop_contradictions(tags: list[str]) -> list[str]:
     if "rule of thirds" in s and "centered composition" in s:
         # 迷ったら映える「rule of thirds」を優先
         s.discard("centered composition")
+    # balanced と centered が同居したら centered を落とす
     if "balanced composition" in s and "centered composition" in s:
         s.discard("centered composition")
 
@@ -290,7 +291,7 @@ def drop_contradictions(tags: list[str]) -> list[str]:
 
 def adjust_framing_for_cues(tokens: list[str]) -> list[str]:
     s = {t.lower().strip() for t in tokens}
-    if s & UPPER_BODY_CUES and "loose framing" in s and "tight framing" not in s:
+    if s & UPPER_BODY_CUES and "loose framing" in s:
         return [
             "tight framing" if t.lower().strip() == "loose framing" else t
             for t in tokens
@@ -314,6 +315,7 @@ REDUNDANT_GROUPS = [
 REDUNDANT_GROUPS += [
     {"gentle tonality", "soft tonality"},
     {"realistic texture", "natural rendition", "clean rendition"},
+    {"window light", "window light pattern"},
 ]
 
 PREFER_ORDER = {
@@ -332,6 +334,7 @@ PREFER_ORDER.update(
     {
         "gentle tonality": 0,
         "realistic texture": 0,
+        "window light": 0,
     }
 )
 

--- a/tests/test_text_filters.py
+++ b/tests/test_text_filters.py
@@ -207,6 +207,8 @@ def test_compress_redundant_merges_similar_terms():
         "soft shadows",
         "gentle tonality",
         "soft tonality",
+        "window light",
+        "window light pattern",
     ]
     out = compress_redundant(tokens)
     assert "warm tones" in out and "warm color palette" not in out
@@ -219,6 +221,7 @@ def test_compress_redundant_merges_similar_terms():
     assert "realistic texture" in out and "natural rendition" not in out and "clean rendition" not in out
     assert "gentle shadow" in out and "subtle shadows" not in out and "soft shadows" not in out
     assert "gentle tonality" in out and "soft tonality" not in out
+    assert "window light" in out and "window light pattern" not in out
 
 
 def test_sync_caption_to_prompt_removes_unused_objects():


### PR DESCRIPTION
## Summary
- Resolve `balanced composition` vs `centered composition` conflicts by dropping `centered composition`
- Automatically convert `loose framing` to `tight framing` when upper-body cues are present
- Consolidate window light synonyms and prefer `window light`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1398c59883288d1222ddac859ac2