### PR TITLE
feat: add style and profile routing

### DIFF
--- a/tests/test_text_filters.py
+++ b/tests/test_text_filters.py
@@ -163,7 +163,7 @@ def test_finalize_pipeline_fills_and_filters():
         "centered composition",
     ]
     cleaned = clean_tokens(sample)
-    out = finalize_pipeline(cleaned)
+    st, pf, out, _cap, _flags = finalize_pipeline(cleaned)
     assert 55 <= len(out) <= 65
     assert "ayami koj ima" not in out
     assert not ({"long hair", "short hair"} & set(out))


### PR DESCRIPTION
## Summary
- add style and profile router with dedicated SAFE_FILL pools
- expose run_pipeline through finalize_pipeline for style-aware prompt generation
- record selected profile and rules flags in CLI output

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af2470810c8328bd413cbb52534ee0